### PR TITLE
specify upper bound for snakemake version for support of subworkflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "jinja2 >= 2.10.3",
     "scipy >= 1.7.3",
     "pygments >= 2.4.2",
-    "snakemake >= 7.10.0",
+    "snakemake >= 7.10.0, < 8.0.0",
     "h5py",
     "shapely",
     "elephant >= 1.0.0",


### PR DESCRIPTION
snakemake >= 8.0.0 introduces breaking changes, including dropping support for the deprecated 'subworkflow' feature which is used in cobrawap. Ultimately, we must adopt the suggested alternative "module" feature to realize the same functionality. See issue #57. For now, this PR limits the snakemake version to < 8.0.0, so that it still works with the corresponding dependencies when installed via pip.