### PR TITLE
Fixed typo into AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-Please see doc/authors.rst for a list of authors and contributors.
+Please see doc/source/authors.rst for a list of authors and contributors.


### PR DESCRIPTION
Fixing a typo in the path of authors.rst file mentioned in this file.