### PR TITLE
Removing useless update of asig name (gives error when name not defined)

### DIFF
--- a/cobrawap/pipeline/stage02_processing/scripts/background_subtraction.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/background_subtraction.py
@@ -59,7 +59,6 @@ if __name__ == '__main__':
 
     new_asig = asig.duplicate_with_new_data(signal)
     new_asig.array_annotations = asig.array_annotations
-    new_asig.name += ""
     new_asig.description += "The mean of each channel was subtracted ({})."\
                         .format(os.path.basename(__file__))
     block.segments[0].analogsignals[0] = new_asig

--- a/cobrawap/pipeline/stage02_processing/scripts/detrending.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/detrending.py
@@ -75,7 +75,6 @@ if __name__ == '__main__':
                                        args.img_name.replace('_channel0', f'_channel{channel}'))
             save_plot(output_path)
 
-    detrend_asig.name += ""
     detrend_asig.description += "Detrended by order {} ({}). "\
                         .format(args.order, os.path.basename(__file__))
     block.segments[0].analogsignals[0] = detrend_asig

--- a/cobrawap/pipeline/stage02_processing/scripts/frequency_filter.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/frequency_filter.py
@@ -39,7 +39,6 @@ if __name__ == '__main__':
                   lowpass_frequency=args.lowpass_frequency*pq.Hz,
                   filter_order=args.order)
 
-    asig.name += ""
     asig.description += "Frequency filtered with [{}, {}]Hz order {} "\
                         .format(args.highpass_frequency,
                                 args.lowpass_frequency,

--- a/cobrawap/pipeline/stage02_processing/scripts/logMUA_estimation.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/logMUA_estimation.py
@@ -185,7 +185,6 @@ if __name__ == '__main__':
                         / args.img_name.replace('_channel0', f'_channel{channel}')
             save_plot(output_path)
 
-    asig.name += ""
     asig.description += "Estimated logMUA signal [{}, {}] Hz ({}). "\
                         .format(args.highpass_frequency, args.lowpass_frequency,
                                 os.path.basename(__file__))

--- a/cobrawap/pipeline/stage02_processing/scripts/normalization.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/normalization.py
@@ -51,7 +51,6 @@ if __name__ == '__main__':
 
     asig = normalize(block.segments[0].analogsignals[0], args.normalize_by)
 
-    asig.name += ""
     asig.description += "Normalized by {} ({})."\
                         .format(args.normalize_by, os.path.basename(__file__))
     block.segments[0].analogsignals[0] = asig

--- a/cobrawap/pipeline/stage02_processing/scripts/phase_transform.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/phase_transform.py
@@ -25,7 +25,6 @@ if __name__ == '__main__':
     asig = asig.duplicate_with_new_data(phase)
     asig.array_annotations = block.segments[0].analogsignals[0].array_annotations
 
-    asig.name += ""
     asig.description += "Phase signal ({}). "\
                         .format(os.path.basename(__file__))
     block.segments[0].analogsignals[0] = asig

--- a/cobrawap/pipeline/stage02_processing/scripts/roi_selection.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/roi_selection.py
@@ -163,7 +163,6 @@ if __name__ == '__main__':
     new_asig = imagesequence_to_analogsignal(tmp_imgseq)
 
     # save data and figure
-    new_asig.name += ""
     new_asig.description += "Border regions with mean intensity below "\
                          + "{args.intensity_threshold} were discarded. "\
                          + "({})".format(os.path.basename(__file__))

--- a/cobrawap/pipeline/stage02_processing/scripts/spatial_downsampling.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/spatial_downsampling.py
@@ -41,7 +41,8 @@ def spatial_smoothing(imgseq, macro_pixel_dim):
 
     imgseq_reduced.annotations.update(imgseq.annotations)
 
-    imgseq_reduced.name = imgseq.name + " "
+    if imgseq.name:
+        imgseq_reduced.name = imgseq.name
     imgseq_reduced.annotations.update(macro_pixel_dim=macro_pixel_dim)
     imgseq_reduced.description = imgseq.description +  \
                 "spatially downsampled ({}).".format(os.path.basename(__file__))
@@ -56,7 +57,7 @@ def plot_downsampled_image(image, output_path):
 
 if __name__ == '__main__':
     args, unknown = CLI.parse_known_args()
-    
+
     block = load_neo(args.data)
     asig = block.segments[0].analogsignals[0]
     imgseq = analogsignal_to_imagesequence(asig)


### PR DESCRIPTION
This PR fixes a bug due to the residual presence of a placeholder for the update of asig name in some scripts of stage 2, e.g. `asig.name += ""`, giving error if `name` attribute was not yet properly initialized. Being useless, when not dangerous, this line has been removed in all the scripts where still present.