### PR TITLE
Fixing cmd interface run_block behavior

### DIFF
--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -521,6 +521,7 @@ def run_block(stage=None, block=None, block_args=None, block_help=False, **kwarg
 
     stage = input_stage(stage=stage)
     block = input_block(stage=stage, block=block)
+block_dir = Path(get_setting('pipeline_path')) / stage / 'scripts'
 
     if block_help:
         block_args += ["--help"]

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -17,11 +17,21 @@ from pprint import pformat
 
 sys.path.append(str(Path(inspect.getfile(lambda: None)).parent))
 sys.path.append(str(Path(inspect.getfile(lambda: None)).parent / "pipeline"))
-from cmd_utils import (create_new_configfile, get_config,
-                       get_initial_available_stages, get_profile, get_setting,
-                       input_profile, is_profile_name_valid, load_config_file,
-                       locate_str_in_list, read_stage_output, set_setting,
-                       setup_entry_stage, working_directory)
+from cmd_utils import (
+    create_new_configfile,
+    get_config,
+    get_initial_available_stages,
+    get_profile,
+    get_setting,
+    input_profile,
+    is_profile_name_valid,
+    load_config_file,
+    locate_str_in_list,
+    read_stage_output,
+    set_setting,
+    setup_entry_stage,
+    working_directory,
+)
 
 log = logging.getLogger()
 logging.basicConfig(level=logging.INFO)
@@ -531,7 +541,10 @@ def run_block(block=None, block_args=None, block_help=False, **kwargs):
     available_blocks = [
         str(script.stem)
         for script in block_dir.iterdir()
-        if os.path.isfile(script) and not str(script.stem).startswith("_") and script.suffix == ".py" and "template" not in script.stem
+        if os.path.isfile(script)
+        and not str(script.stem).startswith("_")
+        and script.suffix == ".py"
+        and "template" not in script.stem
     ]
 
     while block not in available_blocks:

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -531,7 +531,7 @@ def run_block(block=None, block_args=None, block_help=False, **kwargs):
     available_blocks = [
         str(script.stem)
         for script in block_dir.iterdir()
-        if not str(script.stem).startswith("_") and script.suffix == ".py"
+        if os.path.isfile(script) and not str(script.stem).startswith("_") and script.suffix == ".py" and "template" not in script.stem
     ]
 
     while block not in available_blocks:

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -17,21 +17,11 @@ from pprint import pformat
 
 sys.path.append(str(Path(inspect.getfile(lambda: None)).parent))
 sys.path.append(str(Path(inspect.getfile(lambda: None)).parent / "pipeline"))
-from cmd_utils import (
-    create_new_configfile,
-    get_config,
-    get_initial_available_stages,
-    get_profile,
-    get_setting,
-    input_profile,
-    is_profile_name_valid,
-    load_config_file,
-    locate_str_in_list,
-    read_stage_output,
-    set_setting,
-    setup_entry_stage,
-    working_directory,
-)
+from cmd_utils import (create_new_configfile, get_config,
+                       get_initial_available_stages, get_profile, get_setting,
+                       input_profile, is_profile_name_valid, load_config_file,
+                       locate_str_in_list, read_stage_output, set_setting,
+                       setup_entry_stage, working_directory)
 
 log = logging.getLogger()
 logging.basicConfig(level=logging.INFO)
@@ -88,14 +78,16 @@ CLI_init.add_argument(
 
 # Show Settings
 CLI_settings = subparsers.add_parser(
-    "settings", help="display the content of ~/.cobrawap/config",
+    "settings",
+    help="display the content of ~/.cobrawap/config",
 )
 CLI_settings.set_defaults(command="settings")
 
 
 # Configuration
 CLI_create = subparsers.add_parser(
-    "create", help="create configuration for a new dataset".
+    "create",
+    help="create configuration for a new dataset",
 )
 CLI_create.set_defaults(command="create")
 CLI_create.add_argument(
@@ -132,7 +124,8 @@ CLI_create.add_argument(
 
 # Additional configurations
 CLI_profile = subparsers.add_parser(
-    "add_profile", help="create a new configuration for an existing dataset",
+    "add_profile",
+    help="create a new configuration for an existing dataset",
 )
 CLI_profile.set_defaults(command="add_profile")
 CLI_profile.add_argument(
@@ -183,13 +176,6 @@ CLI_stage = subparsers.add_parser(
 )
 CLI_stage.set_defaults(command="run_stage")
 CLI_stage.add_argument(
-    "--profile",
-    type=str,
-    nargs="?",
-    default=None,
-    help="name of the config profile to be analyzed",
-)
-CLI_stage.add_argument(
     "--stage",
     type=str,
     nargs="?",
@@ -197,10 +183,18 @@ CLI_stage.add_argument(
     choices=list(STAGES.keys()),
     help="select individual stage to execute",
 )
+CLI_stage.add_argument(
+    "--profile",
+    type=str,
+    nargs="?",
+    default=None,
+    help="name of the config profile to be analyzed",
+)
 
 # Block
 CLI_block = subparsers.add_parser(
-    "run_block", help="execute an individual block method on some input",
+    "run_block",
+    help="execute an individual block method on some input",
 )
 CLI_block.set_defaults(command="run_block")
 CLI_block.add_argument(
@@ -421,6 +415,9 @@ def add_profile(
 
 
 def run(profile=None, extra_args=None, **kwargs):
+    if profile is None and extra_args and extra_args[0][0] != "-":
+        profile = extra_args.pop(0)
+
     # select profile
     profile = input_profile(profile=profile)
 
@@ -437,7 +434,10 @@ def run(profile=None, extra_args=None, **kwargs):
     return None
 
 
-def run_stage(profile=None, stage=None, extra_args=None, **kwargs):
+def run_stage(stage=None, profile=None, extra_args=None, **kwargs):
+    if stage is None and extra_args and extra_args[0][0] != "-":
+        stage = extra_args.pop(0)
+
     # select profile
     profile = input_profile(profile=profile)
 
@@ -507,6 +507,9 @@ def run_stage(profile=None, stage=None, extra_args=None, **kwargs):
 
 def run_block(block=None, block_args=None, block_help=False, **kwargs):
     stages = get_setting("stages")
+
+    if block is None and block_args and block_args[0][0] != "-":
+        block = block_args.pop(0)
 
     if block:
         try:

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -521,7 +521,8 @@ def run_block(stage=None, block=None, block_args=None, block_help=False, **kwarg
 
     stage = input_stage(stage=stage)
     block = input_block(stage=stage, block=block)
-block_dir = Path(get_setting('pipeline_path')) / stage / 'scripts'
+
+    block_dir = Path(get_setting("pipeline_path")) / stage / "scripts"
 
     if block_help:
         block_args += ["--help"]

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -1,32 +1,44 @@
 #!/usr/bin/env python
 # encoding: utf8
-'''
+"""
 Collaborative Brain Wave Analysis Pipeline (Cobrawap)
-'''
+"""
 
-import os
-import sys
-import logging
 import argparse
-import subprocess
-import shutil
-import re
-from pprint import pformat
-from pathlib import Path
 import inspect
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from pprint import pformat
+
 sys.path.append(str(Path(inspect.getfile(lambda: None)).parent))
-sys.path.append(str(Path(inspect.getfile(lambda: None)).parent / 'pipeline'))
-from cmd_utils import get_setting, set_setting, get_initial_available_stages
-from cmd_utils import is_profile_name_valid, create_new_configfile
-from cmd_utils import input_profile, get_profile, setup_entry_stage
-from cmd_utils import working_directory, load_config_file, get_config
-from cmd_utils import locate_str_in_list, read_stage_output
+sys.path.append(str(Path(inspect.getfile(lambda: None)).parent / "pipeline"))
+from cmd_utils import (
+    create_new_configfile,
+    get_config,
+    get_initial_available_stages,
+    get_profile,
+    get_setting,
+    input_profile,
+    is_profile_name_valid,
+    load_config_file,
+    locate_str_in_list,
+    read_stage_output,
+    set_setting,
+    setup_entry_stage,
+    working_directory,
+)
+
 log = logging.getLogger()
 logging.basicConfig(level=logging.INFO)
 
 
 try:
-    STAGES = get_setting('stages')
+    STAGES = get_setting("stages")
 except Exception as e:
     log.debug(e)
     try:
@@ -35,97 +47,178 @@ except Exception as e:
         log.debug(e)
         STAGES = {}
 
-CLI = argparse.ArgumentParser(prog='cobrawap')
+CLI = argparse.ArgumentParser(prog="cobrawap")
+
 
 def get_parser():
     return CLI
 
+
 # Utility arguments
-CLI.add_argument("-v", "--verbose", action='store_true',
-                help="print additional logging information")
-CLI.add_argument("-V", "--version", action='version')
+CLI.add_argument(
+    "-v",
+    "--verbose",
+    action="store_true",
+    help="print additional logging information",
+)
+CLI.add_argument("-V", "--version", action="version")
 CLI.set_defaults(command=None)
 
 # Initialization
-subparsers = CLI.add_subparsers(help='')
-CLI_init = subparsers.add_parser('init',
-                help='initialize the cobrawap directories (required only once)')
-CLI_init.set_defaults(command='init')
-CLI_init.add_argument("--output_path", type=Path, default=None,
-                      help="directory where the analysis output is stored "
-                           "[default: '~/cobrawap_output/']")
-CLI_init.add_argument("--config_path", type=Path, default=None,
-                      help="directory where the analysis config files are "
-                           "stored [default: '~/cobrawap_config/']")
+subparsers = CLI.add_subparsers(help="")
+CLI_init = subparsers.add_parser(
+    "init",
+    help="initialize the cobrawap directories (required only once)",
+)
+CLI_init.set_defaults(command="init")
+CLI_init.add_argument(
+    "--output_path",
+    type=Path,
+    default=None,
+    help="directory where the analysis output is stored "
+    "[default: '~/cobrawap_output/']",
+)
+CLI_init.add_argument(
+    "--config_path",
+    type=Path,
+    default=None,
+    help="directory where the analysis config files are "
+    "stored [default: '~/cobrawap_config/']",
+)
 
 # Show Settings
-CLI_settings = subparsers.add_parser('settings',
-                        help='display the content of ~/.cobrawap/config')
-CLI_settings.set_defaults(command='settings')
+CLI_settings = subparsers.add_parser(
+    "settings", help="display the content of ~/.cobrawap/config",
+)
+CLI_settings.set_defaults(command="settings")
 
 
 # Configuration
-CLI_create = subparsers.add_parser('create',
-                        help='create configuration for a new dataset')
-CLI_create.set_defaults(command='create')
-CLI_create.add_argument("--data_path", type=Path, nargs='?', default=None,
-                        help="full path to the dataset to be analyzed "
-                             "(or where it will be stored)")
-CLI_create.add_argument("--loading_script_name", nargs='?', type=Path, default=None,
-                        help="name of the data specific loading script "
-                             "(in <config_path>/stage01_data_entry/scripts/)")
-CLI_create.add_argument("--profile", type=str, nargs='?', default=None,
-                        help="profile name of this dataset/application "
-                             "(see profile name conventions in documentation)")
-CLI_create.add_argument("--parent_profile", type=str, nargs='?', default=None,
-                        help="optional parent profile name "
-                             "(see profile name conventions in documentation)")
+CLI_create = subparsers.add_parser(
+    "create", help="create configuration for a new dataset".
+)
+CLI_create.set_defaults(command="create")
+CLI_create.add_argument(
+    "--data_path",
+    type=Path,
+    nargs="?",
+    default=None,
+    help="full path to the dataset to be analyzed (or where it will be stored)",
+)
+CLI_create.add_argument(
+    "--loading_script_name",
+    nargs="?",
+    type=Path,
+    default=None,
+    help="name of the data specific loading script "
+    "(in <config_path>/stage01_data_entry/scripts/)",
+)
+CLI_create.add_argument(
+    "--profile",
+    type=str,
+    nargs="?",
+    default=None,
+    help="profile name of this dataset/application "
+    "(see profile name conventions in documentation)",
+)
+CLI_create.add_argument(
+    "--parent_profile",
+    type=str,
+    nargs="?",
+    default=None,
+    help="optional parent profile name "
+    "(see profile name conventions in documentation)",
+)
 
 # Additional configurations
-CLI_profile = subparsers.add_parser('add_profile',
-                         help='create a new configuration for an existing dataset')
-CLI_profile.set_defaults(command='add_profile')
-CLI_profile.add_argument("--profile", type=str, nargs='?', default=None,
-                        help="profile name of this dataset/application "
-                             "(see profile name conventions in documentation)")
-CLI_profile.add_argument("--stages", type=str, nargs='*',
-                         choices=list(STAGES.keys()), default=None,
-                         help="selection of pipeline stages to configure")
-CLI_profile.add_argument("--parent_profile", type=str, nargs='?', default=None,
-                         help="optional parent profile name from which to "
-                              "initialize the new config "
-                              "[default: basic template]")
+CLI_profile = subparsers.add_parser(
+    "add_profile", help="create a new configuration for an existing dataset",
+)
+CLI_profile.set_defaults(command="add_profile")
+CLI_profile.add_argument(
+    "--profile",
+    type=str,
+    nargs="?",
+    default=None,
+    help="profile name of this dataset/application "
+    "(see profile name conventions in documentation)",
+)
+CLI_profile.add_argument(
+    "--stages",
+    type=str,
+    nargs="*",
+    choices=list(STAGES.keys()),
+    default=None,
+    help="selection of pipeline stages to configure",
+)
+CLI_profile.add_argument(
+    "--parent_profile",
+    type=str,
+    nargs="?",
+    default=None,
+    help="optional parent profile name from which to "
+    "initialize the new config "
+    "[default: basic template]",
+)
 
 # Run
-CLI_run = subparsers.add_parser('run',
-                            help='run the analysis pipeline on the selected '
-                                 'input and with the specified configurations')
-CLI_run.set_defaults(command='run')
-CLI_run.add_argument("--profile", type=str, nargs='?', default=None,
-                     help="name of the config profile to be analyzed")
+CLI_run = subparsers.add_parser(
+    "run",
+    help="run the analysis pipeline on the selected "
+    "input and with the specified configurations",
+)
+CLI_run.set_defaults(command="run")
+CLI_run.add_argument(
+    "--profile",
+    type=str,
+    nargs="?",
+    default=None,
+    help="name of the config profile to be analyzed",
+)
 
 # Stage
-CLI_stage = subparsers.add_parser('run_stage',
-                                  help='execute an individual stage')
-CLI_stage.set_defaults(command='run_stage')
-CLI_stage.add_argument("--profile", type=str, nargs='?', default=None,
-                       help="name of the config profile to be analyzed")
-CLI_stage.add_argument("--stage", type=str, nargs='?', default=None,
-                       choices=list(STAGES.keys()),
-                       help="select individual stage to execute")
+CLI_stage = subparsers.add_parser(
+    "run_stage",
+    help="execute an individual stage",
+)
+CLI_stage.set_defaults(command="run_stage")
+CLI_stage.add_argument(
+    "--profile",
+    type=str,
+    nargs="?",
+    default=None,
+    help="name of the config profile to be analyzed",
+)
+CLI_stage.add_argument(
+    "--stage",
+    type=str,
+    nargs="?",
+    default=None,
+    choices=list(STAGES.keys()),
+    help="select individual stage to execute",
+)
 
 # Block
-CLI_block = subparsers.add_parser('run_block',
-                        help='execute an individual block method on some input')
-CLI_block.set_defaults(command='run_block')
-CLI_block.add_argument("block", type=str, nargs='?', default=None,
-                       help="block specified as <stage_name>.<block_name>")
-CLI_block.add_argument("block_help", action='store_true',
-                       help="display the help text of the block script")
+CLI_block = subparsers.add_parser(
+    "run_block", help="execute an individual block method on some input",
+)
+CLI_block.set_defaults(command="run_block")
+CLI_block.add_argument(
+    "--block",
+    type=str,
+    nargs="?",
+    default=None,
+    help="block specified as <stage_name>.<block_name>",
+)
+CLI_block.add_argument(
+    "--block_help",
+    action="store_true",
+    help="display the help text of the block script",
+)
 
 
 def main():
-    'Start main CLI entry point.'
+    "Start main CLI entry point."
     args, unknown = CLI.parse_known_args()
     # log.info("this is a regular print statement")
     # log.debug("this is a verbose print statement")
@@ -134,31 +227,31 @@ def main():
         log.setLevel(logging.DEBUG)
     log.debug(pformat(args))
 
-    if args.command == 'init':
+    if args.command == "init":
         log.info("initializing Cobrawap")
         initialize(**vars(args))
 
-    elif args.command == 'settings':
+    elif args.command == "settings":
         log.info("display settings at ~/.cobrawap/config")
         print_settings(**vars(args))
 
-    elif args.command == 'create':
+    elif args.command == "create":
         log.info("creating a set of config files")
         create(**vars(args))
 
-    elif args.command == 'add_profile':
+    elif args.command == "add_profile":
         log.info("creating a new config files")
         add_profile(**vars(args))
 
-    elif args.command == 'run':
+    elif args.command == "run":
         log.info("executing Cobrawap")
         run(**vars(args), extra_args=unknown)
 
-    elif args.command == 'run_stage':
+    elif args.command == "run_stage":
         log.info("executing Cobrawap stage")
         run_stage(**vars(args), extra_args=unknown)
 
-    elif args.command == 'run_block':
+    elif args.command == "run_block":
         log.info("executing Cobrawap block")
         run_block(**vars(args), block_args=unknown)
 
@@ -175,9 +268,14 @@ def main():
 def initialize(output_path=None, config_path=None, **kwargs):
     # set output_path
     if output_path is None:
-        output_path = Path(input("Output directory "\
-                                 "[default: ~/cobrawap_output]:")
-                        or Path('~') / 'cobrawap_output').expanduser().resolve()
+        output_path = (
+            Path(
+                input("Output directory " "[default: ~/cobrawap_output]: ")
+                or Path("~") / "cobrawap_output"
+            )
+            .expanduser()
+            .resolve()
+        )
     output_path.mkdir(exist_ok=True)
     if not output_path.is_dir():
         raise ValueError(f"{output_path} is not a valid directory!")
@@ -186,9 +284,14 @@ def initialize(output_path=None, config_path=None, **kwargs):
 
     # set config_path
     if config_path is None:
-        config_path = Path(input("Config directory "\
-                                 "[default: ~/cobrawap_configs]: ") \
-                      or Path('~') / 'cobrawap_configs').expanduser().resolve()
+        config_path = (
+            Path(
+                input("Config directory " "[default: ~/cobrawap_configs]: ")
+                or Path("~") / "cobrawap_configs"
+            )
+            .expanduser()
+            .resolve()
+        )
     config_path.mkdir(parents=True, exist_ok=True)
     if not config_path.is_dir():
         raise ValueError(f"{config_path} is not a valid directory!")
@@ -196,39 +299,48 @@ def initialize(output_path=None, config_path=None, **kwargs):
     set_setting(dict(config_path=str(config_path)))
 
     # set pipeline path
-    pipeline_path = Path(__file__).parents[1] / 'cobrawap' / 'pipeline'
+    pipeline_path = Path(__file__).parents[1] / "cobrawap" / "pipeline"
     set_setting(dict(pipeline_path=str(pipeline_path.resolve())))
 
     # set available stages
     set_setting(dict(stages=get_initial_available_stages()))
-    stages = get_setting('stages')
+    stages = get_setting("stages")
 
     # populate config_path with template config files
     if any(config_path.iterdir()):
-        overwrite = (input(f"The config directory {config_path} already exists "\
-                            "and is not empty. Create template config files "\
-                            "anyway? [y/N]").lower() == 'y'
-                     or False)
+        overwrite = (
+            input(
+                f"The config directory {config_path} already exists "
+                "and is not empty. Create template config files "
+                "anyway? [y/N] "
+            ).lower()
+            == "y"
+            or False
+        )
     else:
         overwrite = True
     if overwrite:
         for stage_number, stage in stages.items():
-            stage_config_path = config_path / stage / 'configs'
+            stage_config_path = config_path / stage / "configs"
             stage_config_path.mkdir(parents=True, exist_ok=True)
-            shutil.copy(pipeline_path / stage / 'configs' \
-                                              / 'config_template.yaml',
-                        stage_config_path / 'config.yaml')
+            shutil.copy(
+                pipeline_path / stage / "configs" / "config_template.yaml",
+                stage_config_path / "config.yaml",
+            )
 
-        pipeline_config_path = config_path / 'configs'
+        pipeline_config_path = config_path / "configs"
         pipeline_config_path.mkdir(parents=True, exist_ok=True)
-        shutil.copy(pipeline_path / 'configs' / 'config_template.yaml',
-                    pipeline_config_path / 'config.yaml')
+        shutil.copy(
+            pipeline_path / "configs" / "config_template.yaml",
+            pipeline_config_path / "config.yaml",
+        )
 
-        stage01_script_path = config_path / stages['1'] / 'scripts'
+        stage01_script_path = config_path / stages["1"] / "scripts"
         stage01_script_path.mkdir(parents=True, exist_ok=True)
-        shutil.copy(pipeline_path / stages['1'] / 'scripts' \
-                                                / 'enter_data_template.py',
-                    stage01_script_path / 'enter_data_template.py')
+        shutil.copy(
+            pipeline_path / stages["1"] / "scripts" / "enter_data_template.py",
+            stage01_script_path / "enter_data_template.py",
+        )
 
     return None
 
@@ -238,51 +350,73 @@ def print_settings(*args, **kwargs):
     return None
 
 
-def create(profile=None, parent_profile=None, data_path=None,
-           loading_script_name=None, **kwargs):
-    profile, parent_profile = get_profile(profile=profile,
-                                          parent_profile=parent_profile)
+def create(
+    profile=None,
+    parent_profile=None,
+    data_path=None,
+    loading_script_name=None,
+    **kwargs,
+):
+    profile, parent_profile = get_profile(
+        profile=profile, parent_profile=parent_profile
+    )
     base_name = parent_profile if parent_profile else profile
 
-    for stage_number, stage in get_setting('stages').items():
-        config_name = profile if '1' in str(stage_number) else base_name
-        create_new_configfile(stage=stage,
-                              profile=config_name,
-                              parent=parent_profile)
+    for stage_number, stage in get_setting("stages").items():
+        config_name = profile if "1" in str(stage_number) else base_name
+        create_new_configfile(
+            stage=stage,
+            profile=config_name,
+            parent=parent_profile,
+        )
 
-    setup_entry_stage(profile=profile,
-                      parent_profile=parent_profile,
-                      data_path=data_path,
-                      loading_script_name=loading_script_name)
+    setup_entry_stage(
+        profile=profile,
+        parent_profile=parent_profile,
+        data_path=data_path,
+        loading_script_name=loading_script_name,
+    )
     return None
 
 
-def add_profile(profile=None, parent_profile=None, stages=None,
-                data_path=None, loading_script_name=None, **kwargs):
-    profile, parent_profile = get_profile(profile=profile,
-                                          parent_profile=parent_profile)
+def add_profile(
+    profile=None,
+    parent_profile=None,
+    stages=None,
+    data_path=None,
+    loading_script_name=None,
+    **kwargs,
+):
+    profile, parent_profile = get_profile(
+        profile=profile, parent_profile=parent_profile
+    )
     # get stage selection
-    stages = ''
+    stages = ""
     while not stages:
-        stages = input("To which stages should this profile be applied? "
-                      f"{list(get_setting('stages').keys())}:")
+        stages = input(
+            "To which stages should this profile be applied? "
+            f"{list(get_setting('stages').keys())}: "
+        )
         try:
-            stages = stages.replace("'","")
-            stages = re.split(',|\s', stages)
+            stages = stages.replace("'", "")
+            stages = re.split(",|\s", stages)
             stages = [stage for stage in stages if stage]
         except Exception as e:
             log.info(e)
-            stages = ''
+            stages = ""
 
     for stage_number in stages:
-        create_new_configfile(stage_number=stage_number,
-                              profile=profile,
-                              parent=parent_profile)
+        create_new_configfile(
+            stage_number=stage_number, profile=profile, parent=parent_profile
+        )
 
-    if any('1' in stage for stage in stages):
-        setup_entry_stage(profile=profile, parent_profile=parent_profile,
-                          data_path=data_path,
-                          loading_script_name=loading_script_name)
+    if any("1" in stage for stage in stages):
+        setup_entry_stage(
+            profile=profile,
+            parent_profile=parent_profile,
+            data_path=data_path,
+            loading_script_name=loading_script_name,
+        )
     return None
 
 
@@ -291,10 +425,10 @@ def run(profile=None, extra_args=None, **kwargs):
     profile = input_profile(profile=profile)
 
     # set runtime config
-    pipeline_path = Path(get_setting('pipeline_path'))
+    pipeline_path = Path(get_setting("pipeline_path"))
 
     # execute snakemake
-    snakemake_args = ['snakemake', '-c1', '--config', f'PROFILE={profile}']
+    snakemake_args = ["snakemake", "-c1", "--config", f"PROFILE={profile}"]
     log.info(f'Executing `{" ".join(snakemake_args+extra_args)}`')
 
     with working_directory(pipeline_path):
@@ -308,51 +442,61 @@ def run_stage(profile=None, stage=None, extra_args=None, **kwargs):
     profile = input_profile(profile=profile)
 
     # get settings
-    pipeline_path = Path(get_setting('pipeline_path'))
-    config_path = Path(get_setting('config_path'))
-    output_path = Path(get_setting('output_path'))
-    stages = get_setting('stages')
+    pipeline_path = Path(get_setting("pipeline_path"))
+    config_path = Path(get_setting("config_path"))
+    output_path = Path(get_setting("output_path"))
+    stages = get_setting("stages")
 
     # select stage
     while stage not in stages.keys():
-        stage = input("Which stage should be executed?\n    "
-            +"\n    ".join(f"{k} {v}" for k,v in get_setting('stages').items())
-            +"\nSelect the stage index: ")
+        stage = input(
+            "Which stage should be executed?\n    "
+            + "\n    ".join(f"{k} {v}" for k, v in get_setting("stages").items())
+            + "\nSelect the stage index: "
+        )
     stage = stages[stage]
 
     # lookup stage input file
-    pipeline_config_path = config_path / 'configs' / 'config.yaml'
+    pipeline_config_path = config_path / "configs" / "config.yaml"
     config_dict = load_config_file(pipeline_config_path)
-    stage_idx = locate_str_in_list(config_dict['STAGES'], stage)
+    stage_idx = locate_str_in_list(config_dict["STAGES"], stage)
     # stage_idx_global = locate_str_in_list([v for k,v in stages.items()], stage)
     if stage_idx is None:
-        raise IndexError("Make sure that the selected stage is also specified "\
-                         "in your top-level config in the list `STAGES`!")
+        raise IndexError(
+            "Make sure that the selected stage is also specified "
+            "in your top-level config in the list `STAGES`!"
+        )
 
-    stage_config_path = get_config(config_dir=config_path / stage,
-                                   config_name=f'config_{profile}.yaml',
-                                   get_path_instead=True)
+    stage_config_path = get_config(
+        config_dir=config_path / stage,
+        config_name=f"config_{profile}.yaml",
+        get_path_instead=True,
+    )
 
     if stage_idx > 0:
-        prev_stage = config_dict['STAGES'][stage_idx-1]
-        prev_stage_config_path = get_config(config_dir=config_path / prev_stage,
-                                            config_name=f'config_{profile}.yaml',
-                                            get_path_instead=True)
+        prev_stage = config_dict["STAGES"][stage_idx - 1]
+        prev_stage_config_path = get_config(
+            config_dir=config_path / prev_stage,
+            config_name=f"config_{profile}.yaml",
+            get_path_instead=True,
+        )
         prev_config_name = Path(prev_stage_config_path).name
-        prev_output_name = read_stage_output(stage=prev_stage,
-                                        config_dir=config_path,
-                                        config_name=prev_config_name)
+        prev_output_name = read_stage_output(
+            stage=prev_stage,
+            config_dir=config_path,
+            config_name=prev_config_name,
+        )
         stage_input = output_path / profile / prev_stage / prev_output_name
-        extra_args = [f'STAGE_INPUT={stage_input}'] + extra_args
+        extra_args = [f"STAGE_INPUT={stage_input}"] + extra_args
 
     # descend into stage folder
     pipeline_path = pipeline_path / stage
 
     # append stage specific arguments
-    extra_args = extra_args + ['--configfile', f'{stage_config_path}']
+    extra_args = extra_args + ["--configfile", f"{stage_config_path}"]
 
     # execute snakemake
-    snakemake_args = ['snakemake', '-c1', '--config', f'PROFILE={profile}']
+    snakemake_args = ["snakemake", "-c1", "--config", f"PROFILE={profile}"]
     log.info(f'Executing `{" ".join(snakemake_args+extra_args)}`')
 
     with working_directory(pipeline_path):
@@ -362,37 +506,47 @@ def run_stage(profile=None, stage=None, extra_args=None, **kwargs):
 
 
 def run_block(block=None, block_args=None, block_help=False, **kwargs):
-    while not block:
-        block = input("Specify a block to execute (<stage_name>.<block_name>):")
+    stages = get_setting("stages")
 
-    stage, block  = re.split("\.|/|\s", block)[:2]
-    stages = get_setting('stages')
+    if block:
+        try:
+            stage, block = re.split("\.|/|\s", block)[:2]
+        except Exception as e:
+            print(e)
+            stage, block = "", ""
+    else:
+        stage, block = "", ""
 
-    while not stage in stages.values():
-        print(f"Stage {stage} not found!\n"\
-              f"Available stages are: {', '.join(list(stages.values()))}.")
-        stage = input("Specify stage:")
+    while stage not in stages.values():
+        print(
+            f"Stage {stage} not found!\n"
+            f"Available stages are: {', '.join(list(stages.values()))}"
+        )
+        stage = input("Select stage: ")
 
-    block_dir = Path(get_setting('pipeline_path')) / stage / 'scripts'
-    available_blocks = [str(script.stem) for script in block_dir.iterdir()
-                        if not str(script.stem).startswith('_')]
+    block_dir = Path(get_setting("pipeline_path")) / stage / "scripts"
+    available_blocks = [
+        str(script.stem)
+        for script in block_dir.iterdir()
+        if not str(script.stem).startswith("_") and script.suffix == ".py"
+    ]
 
-    while not block in available_blocks:
-        print(f"Block {block} is not found in {stage}!\n"\
-              f"Available blocks are: {', '.join(available_blocks)}.")
-        block = input("Specify block:")
+    while block not in available_blocks:
+        print(
+            f"Block {block} is not found in {stage}!\n"
+            f"Available blocks are: {', '.join(available_blocks)}"
+        )
+        block = input("Select block: ")
 
     if block_help:
-        block_args += ['--help']
+        block_args += ["--help"]
 
     # execute block
     myenv = os.environ.copy()
-    myenv['PYTHONPATH'] = ':'.join(sys.path)
-    subprocess.run(['python', str(block_dir / f'{block}.py')]
-                    + block_args,
-                    env=myenv)
+    myenv["PYTHONPATH"] = ":".join(sys.path)
+    subprocess.run(["python", str(block_dir / f"{block}.py")] + block_args, env=myenv)
     return None
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -520,7 +520,7 @@ def run_block(stage=None, block=None, block_args=None, block_help=False, **kwarg
     #     block = block_args.pop(0)
 
     stage = input_stage(stage=stage)
-    block = input_block(stage=None, block=block)
+    block = input_block(stage=stage, block=block)
 
     if block_help:
         block_args += ["--help"]

--- a/cobrawap/cmd_utils.py
+++ b/cobrawap/cmd_utils.py
@@ -101,13 +101,17 @@ def input_block(stage=None, block=None):
 
     block_dir = Path(get_setting("pipeline_path")) / stage / "scripts"
     available_blocks = get_available_blocks(block_dir)
+
     while block not in available_blocks:
-        if not block:
-            print("Which block should be executed?")
+
+        if block:
+            print(f"Block '{block}' is not found in {stage}!")
         else:
-            print(f"Block \'{block}\' is not found in {stage}!")
+            print("Which block should be executed?")
+
         print(f"Available blocks are: {', '.join(available_blocks)}")
         block = input("Select block: ")
+
     return block
 
 

--- a/cobrawap/cmd_utils.py
+++ b/cobrawap/cmd_utils.py
@@ -102,10 +102,11 @@ def input_block(stage=None, block=None):
     block_dir = Path(get_setting("pipeline_path")) / stage / "scripts"
     available_blocks = get_available_blocks(block_dir)
     while block not in available_blocks:
-        print(
-            f"Block {block} is not found in {stage}!\n"
-            f"Available blocks are: {', '.join(available_blocks)}"
-        )
+        if not block:
+            print("Which block should be executed?")
+        else:
+            print(f"Block \'{block}\' is not found in {stage}!")
+        print(f"Available blocks are: {', '.join(available_blocks)}")
         block = input("Select block: ")
     return block
 

--- a/cobrawap/cmd_utils.py
+++ b/cobrawap/cmd_utils.py
@@ -87,7 +87,7 @@ def input_stage(stage=None):
     while stage not in stages.keys() and stage not in stages.values():
         stage = input(
             "Which stage should be executed?\n    "
-            + "\n    ".join(f"{k} {v}" for k, v in get_setting("stages").items())
+            + "\n    ".join(f"{k} {v}" for k, v in stages.items())
             + "\nSelect the stage index: "
         )
     if stage in stages.keys():

--- a/cobrawap/cmd_utils.py
+++ b/cobrawap/cmd_utils.py
@@ -1,16 +1,25 @@
-import os
-import sys
-import logging
-import shutil
-import re
-from string import ascii_lowercase
 import contextlib
 import inspect
+import logging
+import os
+import re
+import shutil
+import sys
 from pathlib import Path
+from pprint import pformat
+from string import ascii_lowercase
+
 sys.path.append(str(Path(inspect.getfile(lambda: None))))
-from pipeline.utils.snakefile import  get_setting, set_setting, get_config
-from pipeline.utils.snakefile import load_config_file, locate_str_in_list
-from pipeline.utils.snakefile import read_stage_output, update_configfile
+from pipeline.utils.snakefile import (
+    get_config,
+    get_setting,
+    load_config_file,
+    locate_str_in_list,
+    read_stage_output,
+    set_setting,
+    update_configfile,
+)
+
 log = logging.getLogger()
 logging.basicConfig(level=logging.INFO)
 
@@ -21,32 +30,37 @@ def create_new_configfile(profile, stage=None, stage_number=None, parent=None):
             raise KeyError("You must either specify `stage` or `stage_number`!")
         else:
 
-            stage = get_setting('stages')[stage_number]
+            stage = get_setting("stages")[stage_number]
 
-    config_path = Path(get_setting('config_path'))
+    config_path = Path(get_setting("config_path"))
 
-    parent = f'_{parent}' if parent else ''
-    config_dir = config_path / stage / 'configs'
-    template_config_path = config_dir / f'config{parent}.yaml'
-    new_config_path = config_dir / f'config_{profile}.yaml'
+    parent = f"_{parent}" if parent else ""
+    config_dir = config_path / stage / "configs"
+    template_config_path = config_dir / f"config{parent}.yaml"
+    new_config_path = config_dir / f"config_{profile}.yaml"
 
     if new_config_path.exists():
         log.debug(f"config file `{new_config_path}` already exists. Skip.")
         return None
-    
+
     if not template_config_path.exists():
         log.debug(f"parent config file `{template_config_path}` doesn't exist.")
-        potential_parents = [f.name for f in config_dir.iterdir() \
-                                    if f.name.startswith(f'config{parent}')]
+        potential_parents = [
+            f.name
+            for f in config_dir.iterdir()
+            if f.name.startswith(f"config{parent}")
+        ]
         if potential_parents:
             log.debug(f"Using `{potential_parents[0]}` instead.")
             template_config_path = config_dir / potential_parents[0]
         else:
-            raise FileNotFoundError("No parent config file fitting the name "
-                                   f"`{parent.strip('_')}` found!")
+            raise FileNotFoundError(
+                "No parent config file fitting the name "
+                f"`{parent.strip('_')}` found!"
+            )
 
     shutil.copy(template_config_path, new_config_path)
-    update_configfile(new_config_path, {'PROFILE':profile})
+    update_configfile(new_config_path, {"PROFILE": profile})
     return None
 
 
@@ -58,15 +72,65 @@ def input_profile(profile=None):
         while not is_profile_name_valid(profile):
             profile = input("profile name: ")
             if not is_profile_name_valid(profile):
-                log.info(f"{profile} is not a valid profile name. "\
-                        "Please use only letters, "\
-                        "'_' (for sub-profile structuring), "\
-                        "or '|' (for variant separation).")
+                log.info(
+                    f"{profile} is not a valid profile name. "
+                    "Please use only letters, "
+                    "'_' (for sub-profile structuring), "
+                    "or '|' (for variant separation)."
+                )
     return profile
-    
+
+
+def input_stage(stage=None):
+    stages = get_setting("stages")
+
+    while stage not in stages.keys() and stage not in stages.values():
+        stage = input(
+            "Which stage should be executed?\n    "
+            + "\n    ".join(f"{k} {v}" for k, v in get_setting("stages").items())
+            + "\nSelect the stage index: "
+        )
+    if stage in stages.keys():
+        stage = stages[stage]
+    return stage
+
+
+def input_block(stage=None, block=None):
+    if stage is None:
+        raise ValueError("Stage must be specified!")
+
+    block_dir = Path(get_setting("pipeline_path")) / stage / "scripts"
+    available_blocks = get_available_blocks(block_dir)
+    while block not in available_blocks:
+        print(
+            f"Block {block} is not found in {stage}!\n"
+            f"Available blocks are: {', '.join(available_blocks)}"
+        )
+        block = input("Select block: ")
+    return block
+
+
+def print_settings(*args, **kwargs):
+    print(pformat(get_setting()))
+    return None
+
+
+def get_available_blocks(block_dir):
+    available_scripts = [
+        script for script in block_dir.iterdir() if os.path.isfile(script)
+    ]
+    available_blocks = [
+        s.stem
+        for s in available_scripts
+        if not (s.stem).startswith("_")
+        and s.suffix == ".py"
+        and "template" not in s.stem
+    ]
+    return available_blocks
+
 
 def is_profile_name_valid(profile: str) -> bool:
-    if type(profile) == str:
+    if isinstance(profile, str):
         profile = profile.strip("'\"")
         pattern = re.compile("[\w\d\|]+")
         return bool(pattern.fullmatch(profile))
@@ -77,83 +141,100 @@ def is_profile_name_valid(profile: str) -> bool:
 def get_profile(profile=None, parent_profile=None):
     # set initial profile name
     profile = input_profile(profile=profile)
-    
+
     # set full profile name
     if parent_profile is None:
         parent_profile = input("Specify the parent profile name [optional]:")
 
-    if is_profile_name_valid(parent_profile) and '|' not in parent_profile \
-    and not profile.startswith(parent_profile):
+    if (
+        is_profile_name_valid(parent_profile)
+        and "|" not in parent_profile
+        and not profile.startswith(parent_profile)
+    ):
         profile = f"{parent_profile}_{profile}"
     elif parent_profile:
-        log.info(f"{parent_profile} is not a valid profile parent name. "\
-                "Ignore.")
+        log.info(f"{parent_profile} is not a valid profile parent name. Ignore.")
         parent_profile = None
     return profile, parent_profile
 
 
-def setup_entry_stage(profile, parent_profile=None, 
-                  data_path=None, loading_script_name=None):
+def setup_entry_stage(
+    profile, parent_profile=None, data_path=None, loading_script_name=None
+):
     """
     Populate an existing config file for stage 01 with a data path and create
     a corresponding loading script from a template.
     """
-    config_path = Path(get_setting('config_path'))
-    
+    config_path = Path(get_setting("config_path"))
+
     stage01_update_dict = {}
 
     # set data path
     if data_path is None:
-        data_path = (input("Path to dataset [optional, "\
-                           "can be set later in the stage01 config file]:")
-                    or None)
+        data_path = (
+            input(
+                "Path to dataset [optional, "
+                "can be set later in the stage01 config file]:"
+            )
+            or None
+        )
     if data_path is not None:
-        stage01_update_dict.update({'DATA_SETS': {profile: data_path}})
-        
+        stage01_update_dict.update({"DATA_SETS": {profile: data_path}})
+
     # set loading script path
     if loading_script_name is None:
         base_profile = parent_profile if parent_profile else profile
 
-        loading_script_name = (input("Loading script name (to be created) "\
-                                "in <config_path>/stage01_data_entry/scripts/ "\
-                                "[default: enter_<profile>.py]:")
-                            or f"enter_{base_profile}.py")
-        if not Path(loading_script_name).suffix == '.py':
+        loading_script_name = (
+            input(
+                "Loading script name (to be created) "
+                "in <config_path>/stage01_data_entry/scripts/ "
+                "[default: enter_<profile>.py]:"
+            )
+            or f"enter_{base_profile}.py"
+        )
+        if not Path(loading_script_name).suffix == ".py":
             loading_script_name = f"{str(Path(loading_script_name).stem)}.py"
-        stage01_update_dict.update({'CURATION_SCRIPT': loading_script_name})
-    
-    stages = get_setting('stages')
-    loading_script_path = config_path / stages['1'] / 'scripts' \
-                                      / f'{loading_script_name}'
+        stage01_update_dict.update({"CURATION_SCRIPT": loading_script_name})
+
+    stages = get_setting("stages")
+    loading_script_path = (
+        config_path / stages["1"] / "scripts" / f"{loading_script_name}"
+    )
     if loading_script_path.exists():
         log.info(f"`{loading_script_name}` already exists. Skip.")
     else:
-        shutil.copy(config_path / stages['1'] / 'scripts' \
-                                              / 'enter_data_template.py',
-                    loading_script_path)
+        shutil.copy(
+            config_path / stages["1"] / "scripts" / "enter_data_template.py",
+            loading_script_path,
+        )
 
     # update stage 01 config
-    stage01_config_path = config_path / stages['1'] / 'configs' \
-                                        / f'config_{profile}.yaml'    
+    stage01_config_path = (
+        config_path / stages["1"] / "configs" / f"config_{profile}.yaml"
+    )
     update_configfile(stage01_config_path, stage01_update_dict)
     return None
 
 
 def get_initial_available_stages():
-    pipeline_path = Path(get_setting('pipeline_path'))
-    stages = [x.name for x in pipeline_path.iterdir() 
-                        if x.is_dir() 
-                        and str(x.name).startswith('stage') 
-                        and 'template' not in x.name]
+    pipeline_path = Path(get_setting("pipeline_path"))
+    stages = [
+        x.name
+        for x in pipeline_path.iterdir()
+        if x.is_dir() and str(x.name).startswith("stage") and "template" not in x.name
+    ]
     stages.sort()
     stage_numbers = [int(re.findall(r"\d+", stage)[0]) for stage in stages]
     stage_keys = []
     for i, v in enumerate(stage_numbers):
         totalcount = stage_numbers.count(v)
         count = stage_numbers[:i].count(v)
-        stage_keys.append(str(v) + ascii_lowercase[count] 
-                            if totalcount > 1 and count > 0 else str(v))
-    return {k:v for k,v in zip(stage_keys, stages)}
+        stage_keys.append(
+            str(v) + ascii_lowercase[count] if totalcount > 1 and count > 0 else str(v)
+        )
+    return {k: v for k, v in zip(stage_keys, stages)}
+
 
 @contextlib.contextmanager
 def working_directory(path):

--- a/cobrawap/cmd_utils.py
+++ b/cobrawap/cmd_utils.py
@@ -88,7 +88,7 @@ def input_stage(stage=None):
         stage = input(
             "Which stage should be executed?\n    "
             + "\n    ".join(f"{k} {v}" for k, v in stages.items())
-            + "\nSelect the stage index: "
+            + "\nSelect the stage index or the stage name: "
         )
     if stage in stages.keys():
         stage = stages[stage]


### PR DESCRIPTION
Fixing a bug discovered by @cosimolupo, the behavior of `run_block` is inconsistent with the other commands, as the block specification and help flag were positional and not keyword args. This PR fixes this issue and improves the selection of blocks when no or a wrong block is given by the user, and directly displays the available stages and blocks to choose from.