### PR TITLE
Changing dependencies requirements to be compliant with EBRAINS ESD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ description = "Collaborative Brain Wave Analysis Pipeline (Cobrawap)"
 version = "0.2.0"
 readme = "README.rst"
 authors = [
-    { name = "Cobrawap authors and contributors", email = "robin.gutzen@outlook.com" }
+    { name = "Cobrawap authors and contributors" }
 ]
 
 requires-python = ">=3.8"
 dependencies = [
-    "ruamel.yaml >= 0.18.3",
+    "ruamel.yaml == 0.17.32",
     "jinja2 >= 2.10.3",
     "scipy >= 1.7.3",
     "pygments >= 2.4.2",
@@ -17,10 +17,11 @@ dependencies = [
     "h5py",
     "shapely",
     "elephant >= 1.0.0",
-    "neo >= 0.10.2, < 0.12",
+    "neo >= 0.10.2",
     "nixio >= 1.5.3",
     "pillow >= 7.0.0",
     "pandas >= 1.2.0",
+    "pulp < 2.8",
     "scikit-learn >= 1.1.0",
     "scikit-image >= 0.20.0",
     "matplotlib >= 3.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Collaborative Brain Wave Analysis Pipeline (Cobrawap)"
 version = "0.2.0"
 readme = "README.rst"
 authors = [
-    { name = "Cobrawap authors and contributors" }
+    { name = "Cobrawap authors and contributors", email = "contact@cobrawap.org"}
 ]
 
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pandas >= 1.2.0",
     "pulp < 2.8",
     "scikit-learn >= 1.1.0",
-    "scikit-image >= 0.20.0",
+    "scikit-image >= 0.19.0",
     "matplotlib >= 3.5.1",
     "seaborn",
     "networkx",

--- a/requirements/environment-docs.yaml
+++ b/requirements/environment-docs.yaml
@@ -9,18 +9,19 @@ dependencies:
   - jinja2 >= 2.10.3
   - pygments >= 2.4.2
   - pygraphviz >= 1.5
-  - snakemake == 7.9.0
+  - snakemake >= 7.10.0 , < 8.0.0
   - h5py
   - shapely
-  - ruamel.yaml >= 0.18.3
+  - ruamel.yaml == 0.17.32
   - pip:
-    - elephant >= 0.10.0
+    - elephant >= 1.0.0
     - neo >= 0.10.2
     - nixio >= 1.5.3
     - pillow >= 7.0.0
     - pandas >= 1.2.0
-    - scikit-learn >= 0.22.1
-    - scikit-image >= 0.19.1
+    - pulp < 2.8
+    - scikit-learn >= 1.1.0
+    - scikit-image >= 0.20.0
     - scipy >= 1.7.3
     - matplotlib >= 3.5.1
     - seaborn


### PR DESCRIPTION
In this Pull Request, the requirements of Cobrawap dependencies have been aligned to the latest [EBRAINS Software Distribution (ESD) guidelines](https://gitlab.ebrains.eu/ri/tech-hub/platform/esd/ebrains-spack-builds).

In more detail, referring to the `pyproject.toml` file:
- the "<0.12" requirement on `neo` has been removed, since the presence of `|`'s in config filenames does not seem to be an issue, at variance with initial guess (see also issue #81 for a discussion on the use of `|`'s in filenames);
- the `ruamel.yaml` version requirement has been slightly changed from ">=0.18.3" to "==0.17.32", in order to have an already compiled version also available via [spack](https://packages.spack.io/package.html?name=py-ruamel-yaml);
- the `pulp` dependency has been explicitly added and pinned to "<2.8", so to be compatible with the current constraint "<8.0" for `snakemake` (see also issues #57 and #82).

In addition, `requirements/environment-docs.yaml` file has been updated accordingly.

Finally, there is a potential change to be done also on `scikit-image`, i.e. relax the version requirement from ">=0.20.0" to ">=0.19.0", so to exploit an already built package in the [ESD pipeline](https://gitlab.ebrains.eu/ri/tech-hub/platform/esd/ebrains-spack-builds). Further checks are needed in this regard.