### PR TITLE
fix broken pypi package generation

### DIFF
--- a/.github/workflows/publish-to-pypi-and-testpypi.yml
+++ b/.github/workflows/publish-to-pypi-and-testpypi.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
Currently, github actions to build wheels for the pypi packages fail with 

```
Current runner version: '2.322.0'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@v4' (SHA:11bd71901bbe5b1630ceea73d27597364c9af683)
Download action repository 'actions/setup-python@v4' (SHA:65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236)
Error: Missing download info for actions/upload-artifact@v3
```