### PR TITLE
Adding the recursive flag parents=True to path.mkdir command for output_path

### DIFF
--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -303,7 +303,7 @@ def initialize(output_path=None, config_path=None, **kwargs):
             .expanduser()
             .resolve()
         )
-    output_path.mkdir(exist_ok=True)
+    output_path.mkdir(parents=True, exist_ok=True)
     if not output_path.is_dir():
         raise ValueError(f"{output_path} is not a valid directory!")
 


### PR DESCRIPTION
As mentioned in the title, and in issue #100, the `cobrawap init` command was missing the recursive flag `parents=True` for the `output_path` folder. This Pull Request adds it.