### PR TITLE
Change from __file__ to inspect.getfile() syntax for path retrieval

### DIFF
--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -40,6 +40,12 @@ from cmd_utils import (
 log = logging.getLogger()
 logging.basicConfig(level=logging.INFO)
 
+# Fetch version number
+try:
+    with open(Path(__file__).parents[1] / 'VERSION') as f:
+        VERSION = f.read().strip()
+except FileNotFoundError:
+    VERSION = "unknown"
 
 try:
     STAGES = get_setting("stages")
@@ -65,7 +71,12 @@ CLI.add_argument(
     action="store_true",
     help="print additional logging information",
 )
-CLI.add_argument("-V", "--version", action="version", version="cobrawap 0.2.1")
+CLI.add_argument(
+    "-V",
+    "--version",
+    action="version",
+    version=f"Cobrawap {VERSION}"
+)
 CLI.set_defaults(command=None)
 
 # Initialization

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -42,7 +42,7 @@ logging.basicConfig(level=logging.INFO)
 
 # Fetch version number
 try:
-    with open(Path(__file__).parents[1] / 'VERSION') as f:
+    with open(Path(inspect.getfile(lambda: None)).parents[1] / 'VERSION') as f:
         VERSION = f.read().strip()
 except FileNotFoundError:
     VERSION = "unknown"
@@ -326,7 +326,7 @@ def initialize(output_path=None, config_path=None, **kwargs):
     set_setting(dict(config_path=str(config_path)))
 
     # set pipeline path
-    pipeline_path = Path(__file__).parents[1] / "cobrawap" / "pipeline"
+    pipeline_path = Path(inspect.getfile(lambda: None)).parent / "pipeline"
     set_setting(dict(pipeline_path=str(pipeline_path.resolve())))
 
     # set available stages

--- a/cobrawap/__main__.py
+++ b/cobrawap/__main__.py
@@ -65,7 +65,7 @@ CLI.add_argument(
     action="store_true",
     help="print additional logging information",
 )
-CLI.add_argument("-V", "--version", action="version")
+CLI.add_argument("-V", "--version", action="version", version="cobrawap 0.2.1")
 CLI.set_defaults(command=None)
 
 # Initialization


### PR DESCRIPTION
In the `__main__.py` file, in the lines retrieving the Cobrawap version from the `VERSION` file, path recognition has been implemented in a different way, moving from `Path(__file__)` to `inspect.getfile(lambda: None)` syntax, because of the former suspected to lead to a failure in readthedocs automatic checks triggered by commits in the NeuralEnsemble official Cobrawap repository. In the same way, again in the `__main__.py` file, also the syntax for retrieving `pipeline_path` has been changed accordingly, and simplified.